### PR TITLE
Remove redundant copying of rms/bin from all ERT model files.

### DIFF
--- a/ert/model/drogon_ahm.ert
+++ b/ert/model/drogon_ahm.ert
@@ -114,7 +114,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/drogon_design.ert
+++ b/ert/model/drogon_design.ert
@@ -113,7 +113,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 

--- a/ert/model/drogon_exercise_02a.ert
+++ b/ert/model/drogon_exercise_02a.ert
@@ -70,7 +70,6 @@ INCLUDE  ../input/config/make_folders.ert
 ---- copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/drogon_exercise_03a.ert
+++ b/ert/model/drogon_exercise_03a.ert
@@ -104,7 +104,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/drogon_exercise_04a.ert
+++ b/ert/model/drogon_exercise_04a.ert
@@ -108,7 +108,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 

--- a/ert/model/drogon_exercise_10a.ert
+++ b/ert/model/drogon_exercise_10a.ert
@@ -105,7 +105,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/tutorial_examples/02_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/02_drogon_ahm.ert
@@ -114,7 +114,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/tutorial_examples/03_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/03_drogon_ahm.ert
@@ -117,7 +117,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/tutorial_examples/04_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/04_drogon_ahm.ert
@@ -112,7 +112,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/tutorial_examples/05_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/05_drogon_ahm.ert
@@ -112,7 +112,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")

--- a/ert/model/tutorial_examples/06_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/06_drogon_ahm.ert
@@ -111,7 +111,6 @@ INCLUDE  ../input/config/make_folders.ert  -- Make general folder structure
 ---- Copy rms folders/files
 -----------------------------------------------------
 
-FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/bin,                  <TO>=<RUNPATH>/rms)
 FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../rms/input/well_modelling, <TO>=<RUNPATH>/rms/input)
 
 --Copy seed file to the rms/model folder --> forces rms to use seed values from the file (target file must be named "random.seeds")


### PR DESCRIPTION
Closes #22 