### PR TITLE
Replace forward model DESIGN2PARAMS with DESIGN_MATRIX keyword

### DIFF
--- a/ert/model/drogon_design.ert
+++ b/ert/model/drogon_design.ert
@@ -130,7 +130,7 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../eclipse/include/schedule
 -- Design matrix uncertainty parameters
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 -----------------------------------------------------
 -- Populate template files with their uncertainty parameter values

--- a/ert/model/drogon_exercise_04a.ert
+++ b/ert/model/drogon_exercise_04a.ert
@@ -125,7 +125,7 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../eclipse/include/schedule
 -- Design matrix uncertainty parameters
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 -----------------------------------------------------
 -- Populate template files with their uncertainty parameter values


### PR DESCRIPTION
This is to replace DESIGN2PARAMS with new DESIGN_MATRIX keyword.
Benefits:
 - validation upon initialization
 - provides overview of design parameters
 - parameters get internalized into the ert storage

requires `ert >= 13.0`. Currently I will keep it as pull request (ie. branch) that can be picked up by komodo releases for testing.