### PR TITLE
Replace forward model DESIGN2PARAMS with DESIGN_MATRIX keyword

### DIFF
--- a/ert/model/drogon_ahm.ert
+++ b/ert/model/drogon_ahm.ert
@@ -145,7 +145,8 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
+
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons

--- a/ert/model/drogon_design.ert
+++ b/ert/model/drogon_design.ert
@@ -130,7 +130,7 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../eclipse/include/schedule
 -- Design matrix uncertainty parameters
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 -----------------------------------------------------
 -- Populate template files with their uncertainty parameter values

--- a/ert/model/drogon_exercise_04a.ert
+++ b/ert/model/drogon_exercise_04a.ert
@@ -125,7 +125,7 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../eclipse/include/schedule
 -- Design matrix uncertainty parameters
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 -----------------------------------------------------
 -- Populate template files with their uncertainty parameter values

--- a/ert/model/tutorial_examples/02_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/02_drogon_ahm.ert
@@ -145,7 +145,7 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons

--- a/ert/model/tutorial_examples/03_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/03_drogon_ahm.ert
@@ -148,7 +148,7 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons

--- a/ert/model/tutorial_examples/04_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/04_drogon_ahm.ert
@@ -143,7 +143,7 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons

--- a/ert/model/tutorial_examples/05_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/05_drogon_ahm.ert
@@ -143,7 +143,7 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons

--- a/ert/model/tutorial_examples/06_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/06_drogon_ahm.ert
@@ -142,7 +142,7 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Special case: get APS prior uncertainty variables from design matrix (instead of GEN_KW) and append to parameters.txt file
 DEFINE  <DESIGN_MATRIX>    ../input/distributions/design_matrix_ahm.xlsx
 DEFINE  <DESIGN_SHEET>     DesignSheet01
-FORWARD_MODEL  DESIGN2PARAMS(<xls_filename>=<CONFIG_PATH>/<DESIGN_MATRIX>, <designsheet>=<DESIGN_SHEET>, <defaultssheet>=DefaultValues)
+DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_SHEET:DefaultValues
 
 ---- 2d parameters ----
 INCLUDE  ../input/config/ahm_surface.ert    -- update horizons


### PR DESCRIPTION
Resolves https://github.com/equinor/ert/issues/10702

This is to replace DESIGN2PARAMS with new DESIGN_MATRIX keyword.
Benefits:
 - validation upon initialization
 - provides overview of design parameters
 - parameters get internalized into the ert storage
 
requires `ert >= 13.0`. Currently I will keep it as pull request (ie. branch) that can be picked up by komodo releases for testing.
