### PR TITLE
Guard eclrun.bash against premature exit

### DIFF
--- a/rms/bin/restore_project_after_git.sh
+++ b/rms/bin/restore_project_after_git.sh
@@ -85,7 +85,9 @@ if [ -d "$GENERIC" ]; then
     echo
 
     sleep 3
+    set +e  # eclrun.bash can trigger exit on string comparisons
     source /prog/res/ecl/script/eclrun.bash #!/bin/sh -> /bin/bash
+    set -e
     runrms --version $VERSION  $GENERIC --batch $GIT_WF_RMS > $RESTORELOG 2>&1
     echo "RMS restore is now finished!"
 else


### PR DESCRIPTION
eclrun.bash is doing string comparisons for load balancing, and that can trigger an early exit when set -e is active