### PR TITLE
Add SUMO_UPLOAD searchpath to the standard results inplace_volumes

### DIFF
--- a/ert/input/config/case_metadata_and_preprocessed_data_sumo.ert
+++ b/ert/input/config/case_metadata_and_preprocessed_data_sumo.ert
@@ -30,3 +30,4 @@ FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/polygons/*.csv")
 FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/grids/*.roff")
 FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/observations/seismic/*.segy")
 FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/seismic/*.segy")
+FORWARD_MODEL SUMO_UPLOAD(<SEARCHPATH>="share/results/tables/volumes/*.parquet")  -- upload standard result: inplace_volumes


### PR DESCRIPTION
Add a new `SUMO_UPLOAD` forward model to enable searching for `parquet` files in the location where the standard result `inplace_volumes` will be stored. 

**Note** currently no files will be present at this location, as the script to create them have only been added locally to the RMS model. The SUMO_UPLOAD job will not fail, it will just look for files with metadata in this location and move on if it dosn't find any. 