### PR TITLE
Add NUM_CPU parameter to ERT models to get rid of warning message.

### DIFF
--- a/ert/model/drogon_exercise_03a.ert
+++ b/ert/model/drogon_exercise_03a.ert
@@ -69,6 +69,7 @@ RANDOM_SEED  123456  -- ERT seed value
 -- LSF settings
 -----------------------------------------------------
 
+NUM_CPU             1
 NUM_REALIZATIONS    5              -- Set number of realizations to run
 MAX_RUNTIME         18000          -- Set the maximum allowed run time (in seconds)
 MIN_REALIZATIONS    1              -- Success criteria

--- a/ert/model/drogon_exercise_04a.ert
+++ b/ert/model/drogon_exercise_04a.ert
@@ -72,6 +72,7 @@ RANDOM_SEED  123456  -- ERT seed value
 -- LSF settings
 -----------------------------------------------------
 
+NUM_CPU             1
 NUM_REALIZATIONS    25             -- Set number of realizations to run
 MAX_RUNTIME         18000          -- Set the maximum allowed run time (in seconds)
 MIN_REALIZATIONS    1              -- Success criteria

--- a/ert/model/drogon_exercise_10a.ert
+++ b/ert/model/drogon_exercise_10a.ert
@@ -71,6 +71,7 @@ RANDOM_SEED  123456  -- ERT seed value
 -- LSF settings
 -----------------------------------------------------
 
+NUM_CPU             1
 NUM_REALIZATIONS    99              -- Set number of realizations to run
 MAX_RUNTIME         18000          -- Set the maximum allowed run time (in seconds)
 MIN_REALIZATIONS    1              -- Success criteria


### PR DESCRIPTION
Added `NUM_CPU `parameter with a value of 1 to drogon_exercise_03a.ert, drogon_exercise_04a.ert, and drogon_exercise_10a.ert to configure the number of CPUs for simulations.

Closes #48 