### PR TITLE
Remove unused `ert_username` from WF_CREATE_CASE_METADATA job.

### DIFF
--- a/ert/bin/workflows/xhook_create_case_metadata
+++ b/ert/bin/workflows/xhook_create_case_metadata
@@ -1,7 +1,7 @@
 -- Create ensemble metadata
 
---                       ert_caseroot                 ert_configpath    ert_casename   ert_username
-WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     <USER>
+--                       ert_caseroot                 ert_configpath    ert_casename
+WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>
 
 -- This workflow is intended to be run as a HOOK workflow.
 -- This workflow job is shipped with Komodo
@@ -9,6 +9,4 @@ WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DI
 
 -- The workflow name is prefixed "xhook" to signal that even if it appears in the ERT
 -- workflow dropdown, it is not supposed to be ran by the user. Also, the "x" in front
--- makes it go to the bottom of the drop-down. When having many HOOK workflows, it is
--- annoying that they take up a lot of space in the ERT dropdown. This is NOT the case
--- in Drogon, with very few workflows, but the routine is useful for setups in the wild.
+-- makes it go to the bottom of the drop-down.

--- a/ert/bin/workflows/xhook_create_case_metadata_sumo
+++ b/ert/bin/workflows/xhook_create_case_metadata_sumo
@@ -1,10 +1,10 @@
 -- Create ensemble metadata and register on Sumo
 
---                       ert_caseroot                 ert_configpath    ert_casename   ert_username   sumo_flag   sum_env
-WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     <USER>         "--sumo"  "--sumo_env" <SUMO_ENV>
+--                       ert_caseroot                 ert_configpath    ert_casename   sumo_flag   sum_env
+WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     "--sumo"    "--sumo_env" <SUMO_ENV>
 
 -- This workflow is intended to be run as a HOOK workflow.
--- This workflow job is shipped with Komodo 
+-- This workflow job is shipped with Komodo
 -- https://fmu-docs.equinor.com/docs/ert/reference/workflows/added_workflow_jobs.html#WF_CREATE_CASE_METADATA
 
 -- The workflow name is prefixed "xhook" to signal that even if it appears in the ERT


### PR DESCRIPTION
- Removed unused `ert_username` parameter from `xhook_create_case_metadata`
- Removed unused `ert_username` parameter from `xhook_create_case_metadata_sumo`

Closes #57 