### PR TITLE
Remove optional `--sumo_env` from xhook_create_case_metadata_sumo

### DIFF
--- a/ert/bin/workflows/xhook_create_case_metadata_sumo
+++ b/ert/bin/workflows/xhook_create_case_metadata_sumo
@@ -1,7 +1,7 @@
 -- Create ensemble metadata and register on Sumo
 
---                       ert_caseroot                 ert_configpath    ert_casename   sumo_flag   sum_env
-WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     "--sumo"    "--sumo_env" <SUMO_ENV>
+--                       ert_caseroot                 ert_configpath    ert_casename   sumo_flag
+WF_CREATE_CASE_METADATA  <SCRATCH>/<USER>/<CASE_DIR>  <CONFIG_PATH>     <CASE_DIR>     "--sumo"
 
 -- This workflow is intended to be run as a HOOK workflow.
 -- This workflow job is shipped with Komodo


### PR DESCRIPTION
Remove --sumo_env arg from create_case_metadata. Still valid argument, but should normally only be used by developers. Will be deprecated in the future in favor of e.g. environment variables or similar.