### PR TITLE
Replace DESIGN_KW with RUN_TEMPLATE in ERT model files.

### DIFF
--- a/ert/input/config/run_ecalc.ert
+++ b/ert/input/config/run_ecalc.ert
@@ -5,7 +5,7 @@
 -------------------------------------------------
 --
 DEFINE  <ECALC_NAME>   drogon_ecalc  -- tmpl and model (yml) file root name
-DEFINE  <ECALC_TMPL>   <CONFIG_PATH>/../../ecalc/model/<ECALC_NAME>.tmpl -- basis for ecalc model file, see DESIGN_KW
+DEFINE  <ECALC_TMPL>   <CONFIG_PATH>/../../ecalc/model/<ECALC_NAME>.tmpl -- basis for ecalc model file, see RUN_TEMPLATE
 
 -----------------------------------------
 
@@ -22,7 +22,7 @@ FORWARD_MODEL COPY_DIRECTORY(<FROM>=<CONFIG_PATH>/../../ecalc/input, <TO>=<RUNPA
 GEN_KW  ECALC  <CONFIG_PATH>/../input/distributions/ecalc.dist
 
 -- set parameter values for the ecalc tmpl/model file
-FORWARD_MODEL DESIGN_KW(<template_file>=<ECALC_TMPL>, <result_file>=ecalc/model/<ECALC_NAME>.yml)
+RUN_TEMPLATE  <ECALC_TMPL>  ecalc/model/<ECALC_NAME>.yml
 
 -----------------------------------------
 

--- a/ert/model/drogon_ahm.ert
+++ b/ert/model/drogon_ahm.ert
@@ -158,11 +158,12 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+--                          INPUT FILE                                                       OUTPUT FILE
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl    <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl             <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl        <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_design.ert
+++ b/ert/model/drogon_design.ert
@@ -136,10 +136,13 @@ DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_
 -- Populate template files with their uncertainty parameter values
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../input/templates/rms_seed.tmpl,                  <result_file>=<RUNPATH>/rms/model/RMS_SEED)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,           <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+--                          INPUT FILE                                                 OUTPUT FILE
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/rms_seed.tmpl           <RUNPATH>/rms/model/RMS_SEED
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_dst.ert
+++ b/ert/model/drogon_dst.ert
@@ -186,11 +186,12 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl, <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,          <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/dual_poro.tmpl,         <result_file>=<RUNPATH>/dual_poro.txt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/dual_poro.tmpl          <RUNPATH>/dual_poro.txt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_exercise_02a.ert
+++ b/ert/model/drogon_exercise_02a.ert
@@ -85,8 +85,10 @@ GEN_KW  GLOBVAR     ../input/distributions/global_variables.dist
 GEN_KW  APS_FACIES  ../input/distributions/facies_aps.dist
 GEN_KW  RATE        ../input/distributions/rate_scaling.dist
 ----------------
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl   <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl       <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_exercise_03a.ert
+++ b/ert/model/drogon_exercise_03a.ert
@@ -138,10 +138,11 @@ GEN_KW  RATE        ../input/distributions/rate_scaling.dist
 -- Populate template files with their uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl    <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_exercise_04a.ert
+++ b/ert/model/drogon_exercise_04a.ert
@@ -1,7 +1,7 @@
 -- ==============================================================================
 --
 -- ERT CONFIGURATION FILE   ----   DROGON RESERVOIR MODEL
---                          "Exercise file running RMS and Eclipse, using DESIGN_KW"
+--                          "Exercise file running RMS and Eclipse, using DESIGN_MATRIX"
 -- Documentation:
 --
 -- References:
@@ -132,10 +132,12 @@ DESIGN_MATRIX <CONFIG_PATH>/<DESIGN_MATRIX> DESIGN_SHEET:<DESIGN_SHEET> DEFAULT_
 -- Populate template files with their uncertainty parameter values
 -----------------------------------------------------
 
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../input/templates/rms_seed.tmpl,                  <result_file>=<RUNPATH>/rms/model/RMS_SEED)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl,    <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,      <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/rms_seed.tmpl            <RUNPATH>/rms/model/RMS_SEED
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl   <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl     <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl       <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/drogon_exercise_10a.ert
+++ b/ert/model/drogon_exercise_10a.ert
@@ -139,10 +139,11 @@ GEN_KW  RATE      ../input/distributions/rate_scaling.dist
 -- Populate template files with their uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt_simple.tmpl    <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
+
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/tutorial_examples/02_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/02_drogon_ahm.ert
@@ -158,11 +158,11 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/tutorial_examples/03_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/03_drogon_ahm.ert
@@ -160,11 +160,11 @@ INCLUDE  ../input/config/ahm_surface.ert    -- update horizons
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/tutorial_examples/04_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/04_drogon_ahm.ert
@@ -155,11 +155,11 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/tutorial_examples/05_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/05_drogon_ahm.ert
@@ -155,11 +155,11 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS

--- a/ert/model/tutorial_examples/06_drogon_ahm.ert
+++ b/ert/model/tutorial_examples/06_drogon_ahm.ert
@@ -154,11 +154,11 @@ INCLUDE  ../input/config/ahm_field_aps.ert  -- update aps grid parameters
 -- Populate template files with their scalar uncertainty parameter values
 -----------------------------------------------------
 
--- DESIGN_KW will fetch the variable values from the parameters.txt file
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl,  <result_file>=<RUNPATH>/fmuconfig/output/global_variables.yml)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../ert/input/templates/multregt.tmpl,  <result_file>=<RUNPATH>/eclipse/include/grid/drogon.multregt)
-FORWARD_MODEL DESIGN_KW(<template_file>=<CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl,  <result_file>=fmuconfig/output/rate_scaling.yml)
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/global_variables.yml.tmpl  <RUNPATH>/fmuconfig/output/global_variables.yml
+RUN_TEMPLATE  <CONFIG_PATH>/../../ert/input/templates/multregt.tmpl           <RUNPATH>/eclipse/include/grid/drogon.multregt
+RUN_TEMPLATE  <CONFIG_PATH>/../../fmuconfig/output/rate_scaling.yml.tmpl      <RUNPATH>/fmuconfig/output/rate_scaling.yml
 
+-- RUN_TEMPLATE uses parameter values from GEN_KW and DESIGN_MATRIX. It does not work with DESIGN2PARAMS.
 
 -----------------------------------------------------
 ---- RMS


### PR DESCRIPTION
- Update all model and exercise .ert files to use `RUN_TEMPLATE` instead of
   `FORWARD_MODEL DESIGN_KW` for template population
- Adjust comments and formatting for clarity and consistency


Closes #77 
