### PR TITLE
Remove deprecated INERNAL False from workflows

### DIFF
--- a/ert/bin/jobs/WF_AVG_PARAM_GEO
+++ b/ert/bin/jobs/WF_AVG_PARAM_GEO
@@ -1,4 +1,3 @@
-INTERNAL    False
 EXECUTABLE  ../scripts/wf_average_parameter_geogrid.py
 MIN_ARG     5
 ARG_TYPE    0  STRING

--- a/ert/bin/jobs/WF_AVG_PARAM_PEM
+++ b/ert/bin/jobs/WF_AVG_PARAM_PEM
@@ -1,4 +1,3 @@
-INTERNAL    False
 EXECUTABLE  ../scripts/wf_average_parameter_pemgrid.py
 MIN_ARG     5
 ARG_TYPE    0  STRING


### PR DESCRIPTION
Not sure if these are actually used.

See https://github.com/equinor/ert/blob/aca683f252cbeda7a9ebc351b9960cba8ae53809/src/ert/config/workflow_job.py#L76